### PR TITLE
Make keypress event be live

### DIFF
--- a/jquery.keyfilter.js
+++ b/jquery.keyfilter.js
@@ -98,7 +98,7 @@
 
 	$.fn.keyfilter = function(re)
 	{
-		return this.keypress(function(e)
+		return this.live('keypress',function(e) {
 		{
 			if (e.ctrlKey || e.altKey)
 			{


### PR DESCRIPTION
In some cases, such as AJAX, the field needs to be assisted by live event.
