### PR TITLE
Invoking the function to setup the $.browser back fill

### DIFF
--- a/jquery.keyfilter.js
+++ b/jquery.keyfilter.js
@@ -31,7 +31,7 @@
 {
 	// $.browser fallback for jQuery 1.9+.
 	if ($.browser === undefined) {
-		$.browser = function () {
+		$.browser = (function () {
 			var ua_match = function (ua) {
 				ua = ua.toLowerCase();
 				var match = /(chrome)[ \/]([\w.]+)/.exec(ua) ||
@@ -57,7 +57,7 @@
 				browser.safari = true;
 			}
 			return browser;
-		};
+		})();
 	}
 
 	var defaultMasks = {


### PR DESCRIPTION
This fixes the issue in Firefox of not being able to delete or use the arrow keys
